### PR TITLE
Add corrupted revisions check and fix functionality

### DIFF
--- a/dokuly/organizations/urls.py
+++ b/dokuly/organizations/urls.py
@@ -40,4 +40,8 @@ urlpatterns = [
         "api/organizations/componentVault/request/",
         views.send_request_to_component_vault,
     ),
+    
+    # Revision system fixes
+    path("api/organizations/checkCorruptedRevisions/", views.check_corrupted_revisions),
+    path("api/organizations/fixCorruptedRevisions/", views.fix_corrupted_revisions_api),
 ]


### PR DESCRIPTION
When testing on a production database the migration failed, thus created a function and button to check and be able to run the new migration function to fix the errors.

- Implemented a new feature in the RevisionSystemSettings component to check for and fix corrupted full part numbers.
- Added API endpoints for checking and fixing corrupted revisions in the backend.
- Enhanced the migration command to include an option for fixing corrupted revisions.
- Updated the UI to display alerts and buttons for checking and fixing corrupted revisions.