### PR TITLE
issues: add author and timestamp to issue creator

### DIFF
--- a/dokuly/frontend/src/components/dokuly_components/dokulyIssues/cards/issueInfoCard.js
+++ b/dokuly/frontend/src/components/dokuly_components/dokulyIssues/cards/issueInfoCard.js
@@ -7,6 +7,7 @@ import { appToModelName } from "../issuesTable";
 import DokulyTags from "../../dokulyTags/dokulyTags";
 import DokulyImage from "../../dokulyImage";
 import { formatCloudImageUri } from "../../../pcbas/functions/productionHelpers";
+import DokulyDateFormat from "../../formatters/dateFormatter";
 
 export const getIssueProject = (issue, returnObject = false) => {
   if (issue?.parts && issue.parts.length > 0) {
@@ -129,6 +130,14 @@ const IssueInfoCard = ({
 
   const affectedItem = getAffectedItemInfo(issue);
 
+  const formatCreatorName = (createdBy) => {
+    if (!createdBy) return "Unknown";
+    if (createdBy.first_name || createdBy.last_name) {
+      return `${createdBy.first_name || ""} ${createdBy.last_name || ""}`.trim();
+    }
+    return createdBy.username || "Unknown";
+  };
+
   return (
     <DokulyCard>
       <CardTitle titleText={"Information"} />
@@ -186,6 +195,28 @@ const IssueInfoCard = ({
             <b>Criticality:</b>
           </Col>
           <Col>{issue?.criticality ?? ""}</Col>
+        </Row>
+
+        <hr />
+
+        <Row className="mt-2">
+          <Col xs="6" sm="6" md="6" lg="4" xl="6">
+            <b>Created by:</b>
+          </Col>
+          <Col>{formatCreatorName(issue?.created_by)}</Col>
+        </Row>
+
+        <Row className="mt-2">
+          <Col xs="6" sm="6" md="6" lg="4" xl="6">
+            <b>Created at:</b>
+          </Col>
+          <Col>
+            {issue?.created_at ? (
+              <DokulyDateFormat date={issue.created_at} showTime={true} />
+            ) : (
+              "N/A"
+            )}
+          </Col>
         </Row>
 
         <hr />

--- a/dokuly/frontend/src/components/dokuly_components/dokulyIssues/issuesTable.js
+++ b/dokuly/frontend/src/components/dokuly_components/dokulyIssues/issuesTable.js
@@ -397,14 +397,13 @@ const IssuesTable = ({
         );
       },
     },
-    /*
     {
       key: "created_by",
       header: "Created By",
       headerTooltip: "Issue creator",
       sortable: true,
       includeInCsv: true,
-      defaultShowColumn: true,
+      defaultShowColumn: false,
       maxWidth: "70px",
       formatter: (row) => {
         return (
@@ -420,7 +419,7 @@ const IssuesTable = ({
       headerTooltip: "Issue creation date",
       sortable: true,
       includeInCsv: true,
-      defaultShowColumn: true,
+      defaultShowColumn: false,
       maxWidth: "60px",
       formatter: (row) => {
         return (
@@ -429,7 +428,7 @@ const IssuesTable = ({
           </div>
         );
       },
-    },*/
+    },
     {
       key: "tags",
       header: "Tags",

--- a/dokuly/projects/viewsIssues.py
+++ b/dokuly/projects/viewsIssues.py
@@ -30,7 +30,7 @@ from projects.viewsTags import check_for_and_create_new_tags
 @renderer_classes([JSONRenderer])
 def get_issue(request, issue_id):
     try:
-        issue = Issues.objects.get(pk=issue_id)
+        issue = Issues.objects.select_related('created_by', 'closed_by', 'description').get(pk=issue_id)
         serializer = IssuesSerializer(issue, many=False)
         issue_data = {}
         issue_data = serializer.data


### PR DESCRIPTION
<img width="1223" height="547" alt="image" src="https://github.com/user-attachments/assets/45b75cae-96d9-462f-9ff5-46913e59b5bd" />
<img width="1263" height="615" alt="image" src="https://github.com/user-attachments/assets/0bebc136-239e-41c1-8ce5-271f667792c1" />


Not including the fields by default in the table, but now the user will have the option to include them.

closes #278 