### PR TITLE
dokulyImage: lazy load images 

### DIFF
--- a/dokuly/frontend/src/components/assemblies/functions/formatBOMImageData.js
+++ b/dokuly/frontend/src/components/assemblies/functions/formatBOMImageData.js
@@ -33,16 +33,14 @@ export const formatBOMImageData = (entry, type) => {
         <DokulyImage
           src={formatCloudImageUri(entry?.thumbnail)}
           alt="Thumbnail"
+          lazy={true}
+          defaultSrc=""
           style={{
             maxWidth: "70px",
             maxHeight: "70px",
             objectFit: "contain",
             display: "block",
             margin: "auto",
-          }}
-          onError={(e) => {
-            e.target.onerror = null;
-            e.target.src = ""; // set default image to no image
           }}
         />
       </div>
@@ -55,13 +53,11 @@ export const formatBOMImageData = (entry, type) => {
         <DokulyImage
           src={`api/files/download/file/${entry?.pcb_renders[0]}`}
           alt="Thumbnail"
+          lazy={true}
+          defaultSrc=""
           style={{
             height: "70px",
             maxWidth: "70px",
-          }}
-          onError={(e) => {
-            e.target.onerror = null;
-            e.target.src = ""; // set default image to no image
           }}
         />
       );
@@ -72,6 +68,12 @@ export const formatBOMImageData = (entry, type) => {
             src="../../static/icons/pcb.svg"
             alt="PCBA Icon"
             title={"Printed circuit board assembly"}
+            loading="lazy"
+            style={{
+              maxWidth: "70px",
+              maxHeight: "70px",
+              objectFit: "contain",
+            }}
           />
         </div>
       );
@@ -88,6 +90,7 @@ export const formatBOMImageData = (entry, type) => {
               alt="Part Image"
               src={entry.image_url}
               title={entry?.part_type?.description || ""}
+              loading="lazy"
             />
           </div>
         );
@@ -103,6 +106,12 @@ export const formatBOMImageData = (entry, type) => {
               src={entry.part_type.icon_url}
               alt="icon"
               title={entry.part_type.description || ""}
+              loading="lazy"
+              style={{
+                maxWidth: "70px",
+                maxHeight: "70px",
+                objectFit: "contain",
+              }}
             />
           </div>
         );
@@ -117,8 +126,14 @@ export const formatBOMImageData = (entry, type) => {
       <div style={containerStyle}>
         <img
           src="../../static/icons/assembly.svg"
-          alt="Assemvly icon"
+          alt="Assembly icon"
           title={"Assembly"}
+          loading="lazy"
+          style={{
+            maxWidth: "70px",
+            maxHeight: "70px",
+            objectFit: "contain",
+          }}
         />
       </div>
     );

--- a/dokuly/frontend/src/components/assemblies/functions/formatters.js
+++ b/dokuly/frontend/src/components/assemblies/functions/formatters.js
@@ -25,16 +25,14 @@ export const thumbnailFormatter = (row) => {
         <DokulyImage
           src={formatCloudImageUri(row?.thumbnail)}
           alt="Thumbnail"
+          lazy={true}
+          defaultSrc=""
           style={{
             maxWidth: "70px",
             maxHeight: "70px",
             objectFit: "contain",
             display: "block",
             margin: "auto",
-          }}
-          onError={(e) => {
-            e.target.onerror = null;
-            e.target.src = ""; // set default image to no image
           }}
         />
       </div>
@@ -46,16 +44,14 @@ export const thumbnailFormatter = (row) => {
         <DokulyImage
           src={row?.image_url}
           alt="Thumbnail"
+          lazy={true}
+          defaultSrc=""
           style={{
             maxWidth: "70px",
             maxHeight: "70px",
             objectFit: "contain",
             display: "block",
             margin: "auto",
-          }}
-          onError={(e) => {
-            e.target.onerror = null;
-            e.target.src = ""; // set default image to no image
           }}
         />
       </div>
@@ -64,7 +60,16 @@ export const thumbnailFormatter = (row) => {
   if(row?.part_type?.icon_url) {
     return (
       <div style={containerStyle}>
-        <img src={row?.part_type?.icon_url} alt="icon" />
+        <img 
+          src={row?.part_type?.icon_url} 
+          alt="icon" 
+          loading="lazy"
+          style={{
+            maxWidth: "70px",
+            maxHeight: "70px",
+            objectFit: "contain",
+          }}
+        />
       </div>
     );
   }

--- a/dokuly/frontend/src/components/dokuly_components/dokulyImage.js
+++ b/dokuly/frontend/src/components/dokuly_components/dokulyImage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { getFile } from "../common/filesTable/functions/queries";
 import { loadingSpinnerCustomMarginAndColor } from "../admin/functions/helperFunctions";
 
@@ -13,59 +13,171 @@ const DokulyImage = ({
   onClick,
   onError,
   onLoad,
+  lazy = true, // Enable lazy loading by default
 }) => {
   const [imageUrl, setImageUrl] = useState("");
   const [loading, setLoading] = useState(true);
+  const [isInView, setIsInView] = useState(!lazy); // If not lazy, start loading immediately
+  const imgRef = useRef(null);
 
+  // Intersection Observer for lazy loading
   useEffect(() => {
-    if (src) {
-      getFile(src)
-        .then((blob) => {
-          const url = window.URL.createObjectURL(blob);
-          setImageUrl(url);
+    if (!lazy || !src || isInView) return;
 
-          // Clean up the created object URL to avoid memory leaks
-          return () => window.URL.revokeObjectURL(url);
-        })
-        .catch((error) => {
-          setImageUrl(defaultSrc || src); // Use defaultSrc if available
-        })
-        .finally(() => {
-          setLoading(false);
-        });
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setIsInView(true);
+            observer.disconnect();
+          }
+        }
+      },
+      {
+        rootMargin: "50px", // Start loading 50px before the image enters viewport
+      }
+    );
+
+    if (imgRef.current) {
+      observer.observe(imgRef.current);
     }
-  }, [src, defaultSrc]);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [lazy, src, isInView]);
+
+  // Load image when in view
+  useEffect(() => {
+    if (!src || !isInView) return;
+
+    let cancelled = false;
+    setLoading(true);
+
+    getFile(src)
+      .then((blob) => {
+        if (cancelled) return;
+        const url = window.URL.createObjectURL(blob);
+        setImageUrl(url);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        // Don't fallback to src - it requires auth and won't work directly
+        // Use defaultSrc or empty string (which will show placeholder)
+        setImageUrl(defaultSrc || "");
+        // Optionally call onError callback if provided
+        if (onError) {
+          onError(error);
+        }
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [src, defaultSrc, isInView, onError]);
+
+  // Cleanup object URL on unmount
+  useEffect(() => {
+    return () => {
+      if (imageUrl?.startsWith("blob:")) {
+        window.URL.revokeObjectURL(imageUrl);
+      }
+    };
+  }, [imageUrl]);
 
   if (!src) {
     return <div />;
   }
 
+  // Calculate placeholder dimensions from style prop
+  const placeholderStyle = {
+    display: "inline-block",
+    backgroundColor: "#f0f0f0",
+    ...(style?.maxWidth && { width: style.maxWidth }),
+    ...(style?.maxHeight && { height: style.maxHeight }),
+    ...(style?.width && { width: style.width }),
+    ...(style?.height && { height: style.height }),
+    minWidth: style?.maxWidth || style?.width || "70px",
+    minHeight: style?.maxHeight || style?.height || "70px",
+  };
+
+  // Handle keyboard events for clickable images
+  const handleKeyDown = (e) => {
+    if ((e.key === "Enter" || e.key === " ") && onClick) {
+      e.preventDefault();
+      onClick(e);
+    }
+  };
+
   if (loading) {
-    return "";
+    return (
+      <div
+        ref={imgRef}
+        style={placeholderStyle}
+        className={className}
+        onClick={onClick}
+        onKeyDown={onClick ? handleKeyDown : undefined}
+        role={onClick ? "button" : "img"}
+        aria-label={alt || "Loading image"}
+        tabIndex={onClick ? 0 : undefined}
+      />
+    );
   }
+
   const defaultStyle = {
     maxWidth: "100%",
     height: "auto",
     ...style, // Allows override of default styles
   };
 
-  return (
-    <img
-      className={className}
-      src={imageUrl}
-      alt={alt}
-      height={height ?? "auto"}
-      width={width ?? "auto"}
-      style={defaultStyle}
-      onClick={onClick}
-      onError={(e) => {
-        e.target.onerror = null;
-        setImageUrl(defaultSrc || src); // Set imageUrl to defaultSrc on error
-        if (onError) onError(e);
-      }}
-      onLoad={onLoad} // Ensure onLoad is forwarded
-    />
-  );
+  const altRule = alt?.trim() ? alt : "Image";
+
+  // Don't render img if imageUrl is empty (error case with no defaultSrc)
+  if (!imageUrl) {
+    return (
+      <div
+        ref={imgRef}
+        style={placeholderStyle}
+        className={className}
+        role="img"
+        aria-label={alt || "Image placeholder"}
+      />
+    );
+  }
+
+  const imgProps = {
+    ref: imgRef,
+    className,
+    src: imageUrl,
+    // Ensure alt is always a non-empty string
+    alt: altRule,
+    // Only set height/width attributes if they're actual numbers/strings (not "auto")
+    ...(height != null && height !== "auto" ? { height } : {}),
+    ...(width != null && width !== "auto" ? { width } : {}),
+    style: defaultStyle,
+    onError: (e) => {
+      e.target.onerror = null;
+      // Don't fallback to src - it requires auth and won't work directly
+      // Use defaultSrc or empty string
+      setImageUrl(defaultSrc || "");
+      if (onError) onError(e);
+    },
+    onLoad, // Ensure onLoad is forwarded
+  };
+
+  if (onClick) {
+    imgProps.onClick = onClick;
+    imgProps.onKeyDown = handleKeyDown;
+    imgProps.role = "button";
+    imgProps.tabIndex = 0;
+  }
+
+  // Explicitly set alt to satisfy linter
+  return <img {...imgProps} alt={altRule} />;
 };
 
 export default DokulyImage;

--- a/dokuly/frontend/src/components/parts/functions/formatters.js
+++ b/dokuly/frontend/src/components/parts/functions/formatters.js
@@ -25,16 +25,14 @@ export const imageFormatter = (cell, row, partTypes) => {
         <DokulyImage
           src={formatCloudImageUri(row?.thumbnail)}
           alt="Thumbnail"
+          lazy={true}
+          defaultSrc=""
           style={{
             maxWidth: "70px",
             maxHeight: "70px",
             objectFit: "contain",
             display: "block",
             margin: "auto",
-          }}
-          onError={(e) => {
-            e.target.onerror = null;
-            e.target.src = ""; // set default image to no image
           }}
         />
       </div>
@@ -48,8 +46,9 @@ export const imageFormatter = (cell, row, partTypes) => {
           className="rounded float-left"
           width="40px"
           height="40px"
-          alt="Part Image"
+          alt="Part thumbnail"
           src={row.image_url}
+          loading="lazy"
           onError={(e) => {
             e.target.onerror = null;
             e.target.src = ""; // set default image to no image
@@ -57,7 +56,8 @@ export const imageFormatter = (cell, row, partTypes) => {
         />
       </div>
     );
-  } else if (partTypes !== undefined && partTypes != null) {
+  }
+  if (partTypes !== undefined && partTypes != null) {
     const partType = partTypes.find((type) => type.id === row.part_type);
     if (
       partType !== undefined &&
@@ -71,6 +71,12 @@ export const imageFormatter = (cell, row, partTypes) => {
             src={partType.icon_url}
             alt="icon"
             title={partType.description || ""}
+            loading="lazy"
+            style={{
+              maxWidth: "70px",
+              maxHeight: "70px",
+              objectFit: "contain",
+            }}
           />
         </div>
       );

--- a/dokuly/frontend/src/components/pcbas/functions/formatters.js
+++ b/dokuly/frontend/src/components/pcbas/functions/formatters.js
@@ -122,11 +122,6 @@ export function ThumbnailFormatterComponent({ row }) {
     }
   };
 
-  const handleError = (e) => {
-    e.target.onerror = null;
-    e.target.src = ""; // set default image to no image
-  };
-
   if (!thumbnailUrl) {
     return <div />;
   }
@@ -162,9 +157,11 @@ export function ThumbnailFormatterComponent({ row }) {
         src={thumbnailUrl}
         defaultSrc={defaultSrc}
         alt="Thumbnail"
+        lazy={true}
         style={imageStyle}
         onLoad={handleImageLoad}
-        onError={handleError}
+        // Remove onError handler - let DokulyImage handle errors internally
+        // It will use defaultSrc on error, which is already set above
       />
     </div>
   );


### PR DESCRIPTION
Use IntersectionObserver for "only fetch when object in view in DOM" to lazily load the images for DokulyImage (used in the part table, thumbnail etc.)