### PR TITLE
Fix Material theme on dokuly.com

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Dokuly Docs
 site_description: Open-source Product Lifecycle Management — documentation and feature guide
-site_url: https://dokuly-plm.github.io/dokuly/
+site_url: https://dokuly.com/
 
 nav:
   - Home: index.md
@@ -43,7 +43,6 @@ theme:
     - navigation.expand
     - navigation.top
     - navigation.indexes
-    - toc.integrate
     - content.code.copy
   favicon: img/favicon.ico
 


### PR DESCRIPTION
## Summary
- Fix `site_url` to match CNAME (`dokuly.com`) — the old GitHub Pages URL caused all CSS/JS assets to 404
- Remove `toc.integrate` so the left sidebar navigation renders properly

## Test plan
- [ ] Verify Material theme renders with green header, left sidebar, and page TOC on dokuly.com after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)