### PR TITLE
docs: fix revision number not matching template

### DIFF
--- a/dokuly/documents/views.py
+++ b/dokuly/documents/views.py
@@ -8,6 +8,7 @@ import tempfile
 import os
 import shutil
 
+from organizations.models import Organization as OrgModel
 from organizations.revision_utils import build_full_document_number
 from organizations.revision_utils import increment_revision_counters, build_formatted_revision
 from part_numbers.methods import get_next_part_number
@@ -231,6 +232,12 @@ def create_new_document(request, **kwargs):
 
         document.save()
 
+        try:
+            _org = OrgModel.objects.get(id=organization_id)
+            doc_revision_format = _org.document_revision_format
+        except Exception:
+            doc_revision_format = "major-only"
+
         document.formatted_revision = build_formatted_revision(
             organization_id=organization_id,
             prefix=prefix.prefix,
@@ -238,7 +245,8 @@ def create_new_document(request, **kwargs):
             revision_count_major=document.revision_count_major,
             revision_count_minor=document.revision_count_minor,
             project_number=document.project.full_project_number if document.project else None,
-            created_at=document.created_at
+            created_at=document.created_at,
+            revision_format=doc_revision_format,
         )
         
         # Use template-based document number generation
@@ -996,6 +1004,12 @@ def auto_new_revision(request, pk, **kwargs):
         prefix = Document_Prefix.objects.get(pk=old_revision.prefix_id) if old_revision.prefix_id and old_revision.prefix_id != -1 else None
         prefix_str = prefix.prefix if prefix else ""
 
+        try:
+            _org = OrgModel.objects.get(id=organization_id)
+            doc_revision_format = _org.document_revision_format
+        except Exception:
+            doc_revision_format = "major-only"
+
         new_revision.formatted_revision = build_formatted_revision(
             organization_id=organization_id,
             prefix=prefix_str,
@@ -1003,7 +1017,8 @@ def auto_new_revision(request, pk, **kwargs):
             revision_count_major=new_revision.revision_count_major,
             revision_count_minor=new_revision.revision_count_minor,
             project_number=new_revision.project.full_project_number if new_revision.project else None,
-            created_at=new_revision.created_at
+            created_at=new_revision.created_at,
+            revision_format=doc_revision_format,
         )
 
         # Use template-based document number generation

--- a/dokuly/frontend/src/components/admin/adminComponents/documents/documentNumberSettings.js
+++ b/dokuly/frontend/src/components/admin/adminComponents/documents/documentNumberSettings.js
@@ -43,6 +43,7 @@ const DocumentNumberSettings = ({ org, setRefresh }) => {
           template: fullDocumentNumberTemplate,
           use_number_revisions: useNumberRevisions,
           start_major_revision_at_one: revisionStartAtOne,
+          revision_format: revisionFormat,
         });
         
         if (response.status === 200) {

--- a/dokuly/frontend/src/components/admin/adminComponents/general/revisionSystemSettings.js
+++ b/dokuly/frontend/src/components/admin/adminComponents/general/revisionSystemSettings.js
@@ -1,6 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { Form, Row, Col, Dropdown } from "react-bootstrap";
-import { editOrg, previewPartNumberTemplate, previewFormattedRevisionTemplate } from "../../functions/queries";
+import {
+  editOrg,
+  previewPartNumberTemplate,
+  previewFormattedRevisionTemplate,
+} from "../../functions/queries";
 import { toast } from "react-toastify";
 import SubmitButton from "../../../dokuly_components/submitButton";
 import CheckBox from "../../../dokuly_components/checkBox";
@@ -9,33 +13,38 @@ import QuestionToolTip from "../../../dokuly_components/questionToolTip";
 
 const RevisionSystemSettings = ({ org, setRefresh }) => {
   const [useNumberRevisions, setUseNumberRevisions] = useState(
-    org?.use_number_revisions || false
+    org?.use_number_revisions || false,
   );
   const [revisionFormat, setRevisionFormat] = useState(
-    org?.revision_format || "major-minor"
+    org?.revision_format || "major-minor",
   );
   const [revisionStartAtOne, setRevisionStartAtOne] = useState(
-    org?.start_major_revision_at_one || false
+    org?.start_major_revision_at_one || false,
   );
   const [fullPartNumberTemplate, setFullPartNumberTemplate] = useState(
-    org?.full_part_number_template || "<prefix><part_number><revision>"
+    org?.full_part_number_template || "<prefix><part_number><revision>",
   );
   const [formattedRevisionTemplate, setFormattedRevisionTemplate] = useState(
-    org?.formatted_revision_template || "<major_revision>"
+    org?.formatted_revision_template || "<major_revision>",
   );
   const [isUpdating, setIsUpdating] = useState(false);
   const [previewExamples, setPreviewExamples] = useState([]);
   const [isLoadingPreview, setIsLoadingPreview] = useState(false);
   const [revisionPreviewExamples, setRevisionPreviewExamples] = useState([]);
-  const [isLoadingRevisionPreview, setIsLoadingRevisionPreview] = useState(false);
+  const [isLoadingRevisionPreview, setIsLoadingRevisionPreview] =
+    useState(false);
 
   // Update state when org prop changes
   useEffect(() => {
     if (org) {
       setUseNumberRevisions(org.use_number_revisions || false);
       setRevisionFormat(org.revision_format || "major-minor");
-      setFullPartNumberTemplate(org.full_part_number_template || "<prefix><part_number><revision>");
-      setFormattedRevisionTemplate(org.formatted_revision_template || "<major_revision>");
+      setFullPartNumberTemplate(
+        org.full_part_number_template || "<prefix><part_number><revision>",
+      );
+      setFormattedRevisionTemplate(
+        org.formatted_revision_template || "<major_revision>",
+      );
       setRevisionStartAtOne(org.start_major_revision_at_one || false);
     }
   }, [org]);
@@ -49,13 +58,14 @@ const RevisionSystemSettings = ({ org, setRefresh }) => {
           template: fullPartNumberTemplate,
           use_number_revisions: useNumberRevisions,
           start_major_revision_at_one: revisionStartAtOne,
+          revision_format: revisionFormat,
         });
-        
+
         if (response.status === 200) {
           setPreviewExamples(response.data.examples || []);
         }
       } catch (error) {
-        console.error('Error fetching template preview:', error);
+        console.error("Error fetching template preview:", error);
         setPreviewExamples([]);
       } finally {
         setIsLoadingPreview(false);
@@ -65,7 +75,12 @@ const RevisionSystemSettings = ({ org, setRefresh }) => {
     // Debounce the preview fetch
     const timeoutId = setTimeout(fetchPreview, 300);
     return () => clearTimeout(timeoutId);
-  }, [fullPartNumberTemplate, useNumberRevisions, revisionStartAtOne]);
+  }, [
+    fullPartNumberTemplate,
+    useNumberRevisions,
+    revisionStartAtOne,
+    revisionFormat,
+  ]);
 
   // Fetch formatted revision preview from backend whenever settings change
   useEffect(() => {
@@ -78,12 +93,12 @@ const RevisionSystemSettings = ({ org, setRefresh }) => {
           revision_format: revisionFormat,
           start_major_revision_at_one: revisionStartAtOne,
         });
-        
+
         if (response.status === 200) {
           setRevisionPreviewExamples(response.data.examples || []);
         }
       } catch (error) {
-        console.error('Error fetching revision template preview:', error);
+        console.error("Error fetching revision template preview:", error);
         setRevisionPreviewExamples([]);
       } finally {
         setIsLoadingRevisionPreview(false);
@@ -93,7 +108,12 @@ const RevisionSystemSettings = ({ org, setRefresh }) => {
     // Debounce the preview fetch
     const timeoutId = setTimeout(fetchRevisionPreview, 300);
     return () => clearTimeout(timeoutId);
-  }, [formattedRevisionTemplate, useNumberRevisions, revisionFormat, revisionStartAtOne]);
+  }, [
+    formattedRevisionTemplate,
+    useNumberRevisions,
+    revisionFormat,
+    revisionStartAtOne,
+  ]);
 
   const handleSave = async () => {
     setIsUpdating(true);
@@ -107,11 +127,11 @@ const RevisionSystemSettings = ({ org, setRefresh }) => {
       };
 
       const response = await editOrg(org.id, data);
-      
+
       if (response.status === 200) {
         toast.success("Revision system settings updated successfully.");
         setRefresh(true);
-        
+
         // Don't auto-check for corrupted revisions after saving
       } else {
         toast.error("Failed to update revision system settings.");
@@ -127,52 +147,70 @@ const RevisionSystemSettings = ({ org, setRefresh }) => {
   const handleReset = () => {
     setUseNumberRevisions(org?.use_number_revisions || false);
     setRevisionFormat(org?.revision_format || "major-minor");
-    setFullPartNumberTemplate(org?.full_part_number_template || "<prefix><part_number><revision>");
-    setFormattedRevisionTemplate(org?.formatted_revision_template || "<major_revision>");
+    setFullPartNumberTemplate(
+      org?.full_part_number_template || "<prefix><part_number><revision>",
+    );
+    setFormattedRevisionTemplate(
+      org?.formatted_revision_template || "<major_revision>",
+    );
     setRevisionStartAtOne(org?.start_major_revision_at_one || false);
   };
 
-  const hasChanges = 
+  const hasChanges =
     useNumberRevisions !== (org?.use_number_revisions || false) ||
     revisionFormat !== (org?.revision_format || "major-minor") ||
-    fullPartNumberTemplate !== (org?.full_part_number_template || "<prefix><part_number><revision>") ||
-    formattedRevisionTemplate !== (org?.formatted_revision_template || "<major_revision>") ||
+    fullPartNumberTemplate !==
+      (org?.full_part_number_template || "<prefix><part_number><revision>") ||
+    formattedRevisionTemplate !==
+      (org?.formatted_revision_template || "<major_revision>") ||
     revisionStartAtOne !== (org?.start_major_revision_at_one || false);
 
   // Available template keywords
   const availableKeywords = [
-    { keyword: '<prefix>', description: 'Part type (PRT, ASM, PCBA)' },
-    { keyword: '<part_number>', description: 'Numeric part number' },
-    { keyword: '<major_revision>', description: 'Major revision (A, B, C or 0, 1, 2)' },
-    { keyword: '<minor_revision>', description: 'Minor revision (A, B, C or 0, 1, 2)' },
-    { keyword: '<revision>', description: 'Major Revision (A, B, C or 0, 1, 2)' },
-    { keyword: '<project_number>', description: 'Project number (if applicable)' },
-    { keyword: '<day>', description: 'Day of creation (01-31)' },
-    { keyword: '<month>', description: 'Month of creation (01-12)' },
-    { keyword: '<year>', description: 'Year of creation (e.g., 2025)' },
+    { keyword: "<prefix>", description: "Part type (PRT, ASM, PCBA)" },
+    { keyword: "<part_number>", description: "Numeric part number" },
+    {
+      keyword: "<major_revision>",
+      description: "Major revision (A, B, C or 0, 1, 2)",
+    },
+    {
+      keyword: "<minor_revision>",
+      description: "Minor revision (A, B, C or 0, 1, 2)",
+    },
+    {
+      keyword: "<revision>",
+      description: "Major Revision (A, B, C or 0, 1, 2)",
+    },
+    {
+      keyword: "<project_number>",
+      description: "Project number (if applicable)",
+    },
+    { keyword: "<day>", description: "Day of creation (01-31)" },
+    { keyword: "<month>", description: "Month of creation (01-12)" },
+    { keyword: "<year>", description: "Year of creation (e.g., 2025)" },
   ];
 
   // Helper function to render template with highlighted keywords
   const renderTemplateWithHighlights = (template) => {
     if (!template) return null;
-    
-    const keywords = availableKeywords.map(k => k.keyword);
+
+    const keywords = availableKeywords.map((k) => k.keyword);
     const parts = [];
     let lastIndex = 0;
-    
+
     // Find all keyword matches and their positions
     const matches = [];
-    keywords.forEach(keyword => {
+    keywords.forEach((keyword) => {
       let index = template.indexOf(keyword);
       while (index !== -1) {
         matches.push({ keyword, index });
         index = template.indexOf(keyword, index + 1);
       }
     });
-    
+
     // Sort matches by position
     matches.sort((a, b) => a.index - b.index);
-    
+
     // Build the rendered output
     matches.forEach(({ keyword, index }) => {
       // Add text before the keyword
@@ -180,40 +218,40 @@ const RevisionSystemSettings = ({ org, setRefresh }) => {
         parts.push(
           <span key={`text-${lastIndex}`}>
             {template.substring(lastIndex, index)}
-          </span>
+          </span>,
         );
       }
-      
+
       // Add the highlighted keyword
       parts.push(
         <span
           key={`keyword-${index}`}
           style={{
-            backgroundColor: '#155216',
-            color: '#ffffff',
-            padding: '2px 4px',
-            borderRadius: '3px',
-            fontFamily: 'monospace',
-            fontSize: '0.9em',
+            backgroundColor: "#155216",
+            color: "#ffffff",
+            padding: "2px 4px",
+            borderRadius: "3px",
+            fontFamily: "monospace",
+            fontSize: "0.9em",
           }}
         >
           {keyword}
-        </span>
+        </span>,
       );
-      
+
       lastIndex = index + keyword.length;
     });
-    
+
     // Add remaining text
     if (lastIndex < template.length) {
       parts.push(
-        <span key={`text-${lastIndex}`}>
-          {template.substring(lastIndex)}
-        </span>
+        <span key={`text-${lastIndex}`}>{template.substring(lastIndex)}</span>,
       );
     }
-    
-    return <div style={{ fontFamily: 'monospace', fontSize: '1em' }}>{parts}</div>;
+
+    return (
+      <div style={{ fontFamily: "monospace", fontSize: "1em" }}>{parts}</div>
+    );
   };
 
   return (
@@ -222,272 +260,324 @@ const RevisionSystemSettings = ({ org, setRefresh }) => {
         <b>Revision System Settings</b>
       </h3>
       <p className="text-muted mb-3">
-        Configure how revisions are displayed and managed for parts, assemblies, PCBAs, and documents. 
-        Use the template to control the exact formatting including separators.
+        Configure how revisions are displayed and managed for parts, assemblies,
+        PCBAs, and documents. Use the template to control the exact formatting
+        including separators.
       </p>
-        
-        <Form>
+
+      <Form>
+        <Row>
+          <Col md={12}>
+            <Form.Group className="mb-3">
+              <CheckBox
+                id="use-number-revisions"
+                label="Use number-based revisions"
+                checked={useNumberRevisions}
+                onChange={(e) => setUseNumberRevisions(e.target.checked)}
+              />
+              <Form.Text className="text-muted">
+                When enabled, revisions will use numbers instead of letters. By
+                default, number revisions start at 0 (0, 1, 2...), but you can
+                configure them to start at 1 using the setting below.
+              </Form.Text>
+            </Form.Group>
+          </Col>
+        </Row>
+
+        {useNumberRevisions && (
           <Row>
             <Col md={12}>
               <Form.Group className="mb-3">
                 <CheckBox
-                  id="use-number-revisions"
-                  label="Use number-based revisions"
-                  checked={useNumberRevisions}
-                  onChange={(e) => setUseNumberRevisions(e.target.checked)}
+                  id="revision-start-at-one"
+                  label="Start major revisions at 1"
+                  checked={revisionStartAtOne}
+                  onChange={(e) => setRevisionStartAtOne(e.target.checked)}
                 />
                 <Form.Text className="text-muted">
-                  When enabled, revisions will use numbers instead of letters. By default, number revisions start at 0 (0, 1, 2...), but you can configure them to start at 1 using the setting below.
+                  When enabled, major revisions will display starting at 1
+                  instead of 0 (e.g., 1, 2, 3... instead of 0, 1, 2...). Minor
+                  revisions always start at 0 regardless of this setting (e.g.,
+                  1-0, 1-1, 1-2, 2-0...). This only affects how revisions are
+                  displayed, not how they are stored in the database.
                 </Form.Text>
               </Form.Group>
             </Col>
           </Row>
+        )}
 
-          {useNumberRevisions && (
-            <Row>
-              <Col md={12}>
-                <Form.Group className="mb-3">
-                  <CheckBox
-                    id="revision-start-at-one"
-                    label="Start major revisions at 1"
-                    checked={revisionStartAtOne}
-                    onChange={(e) => setRevisionStartAtOne(e.target.checked)}
-                  />
-                  <Form.Text className="text-muted">
-                    When enabled, major revisions will display starting at 1 instead of 0 (e.g., 1, 2, 3... instead of 0, 1, 2...). 
-                    Minor revisions always start at 0 regardless of this setting (e.g., 1-0, 1-1, 1-2, 2-0...). 
-                    This only affects how revisions are displayed, not how they are stored in the database.
-                  </Form.Text>
-                </Form.Group>
-              </Col>
-            </Row>
-          )}
+        <Row>
+          <Col md={12}>
+            <Form.Group className="mb-3">
+              <Form.Label>Revision Format</Form.Label>
+              <DokulyDropdown
+                title={
+                  revisionFormat === "major-only"
+                    ? useNumberRevisions
+                      ? revisionStartAtOne
+                        ? "Major Only (1, 2, 3...)"
+                        : "Major Only (0, 1, 2...)"
+                      : "Major Only (A, B, C...)"
+                    : useNumberRevisions
+                      ? revisionStartAtOne
+                        ? "Major-Minor (1-0, 1-1, 2-0...)"
+                        : "Major-Minor (0-0, 0-1, 1-0...)"
+                      : "Major-Minor (A-A, A-B, B-A...)"
+                }
+                variant="outline-secondary"
+              >
+                {({ closeDropdown }) => (
+                  <>
+                    <Dropdown.Item
+                      onClick={() => {
+                        setRevisionFormat("major-only");
+                        closeDropdown();
+                      }}
+                      active={revisionFormat === "major-only"}
+                    >
+                      {useNumberRevisions
+                        ? revisionStartAtOne
+                          ? "Major Only (1, 2, 3...)"
+                          : "Major Only (0, 1, 2...)"
+                        : "Major Only (A, B, C...)"}
+                    </Dropdown.Item>
+                    <Dropdown.Item
+                      onClick={() => {
+                        setRevisionFormat("major-minor");
+                        closeDropdown();
+                      }}
+                      active={revisionFormat === "major-minor"}
+                    >
+                      {useNumberRevisions
+                        ? revisionStartAtOne
+                          ? "Major-Minor (1-0, 1-1, 2-0...)"
+                          : "Major-Minor (0-0, 0-1, 1-0...)"
+                        : "Major-Minor (A-A, A-B, B-A...)"}
+                    </Dropdown.Item>
+                  </>
+                )}
+              </DokulyDropdown>
+              <Form.Text className="text-muted">
+                Choose the format for {useNumberRevisions ? "number" : "letter"}
+                -based revisions. Major-minor format allows for more granular
+                versioning with sub-revisions.
+                {useNumberRevisions &&
+                  `For number-based revisions, the starting value shown above depends on the "Start major revisions at 1" setting.`}
+              </Form.Text>
+            </Form.Group>
+          </Col>
+        </Row>
 
-          <Row>
-            <Col md={12}>
-              <Form.Group className="mb-3">
-                <Form.Label>Revision Format</Form.Label>
-                <DokulyDropdown
-                  title={
-                    revisionFormat === "major-only" 
-                      ? useNumberRevisions 
-                        ? (revisionStartAtOne ? "Major Only (1, 2, 3...)" : "Major Only (0, 1, 2...)")
-                        : "Major Only (A, B, C...)"
-                      : useNumberRevisions 
-                        ? (revisionStartAtOne ? "Major-Minor (1-0, 1-1, 2-0...)" : "Major-Minor (0-0, 0-1, 1-0...)")
-                        : "Major-Minor (A-A, A-B, B-A...)"
+        <Row>
+          <Col md={12}>
+            <Form.Group className="mb-3">
+              <Form.Label>
+                Part Number Template
+                <QuestionToolTip
+                  placement="right"
+                  optionalHelpText={
+                    "Configure how full part numbers are formatted. Available variables:\n" +
+                    "• <prefix> - Part type (PRT, ASM, PCBA, DOC)\n" +
+                    "• <part_number> - Numeric part number\n" +
+                    "• <major_revision> - Major revision (A, B, C or 0, 1, 2)\n" +
+                    "• <minor_revision> - Minor revision (A, B, C or 0, 1, 2)\n" +
+                    "• <revision> - Complete revision string (includes separator)\n" +
+                    "• <project_number> - Project number from associated project\n" +
+                    "• <day> - Day from creation date (01-31)\n" +
+                    "• <month> - Month from creation date (01-12)\n" +
+                    "• <year> - Year from creation date (e.g., 2025)\n\n" +
+                    "Example: '<prefix><part_number>-<revision>' → 'PRT10001-A-0'"
                   }
-                  variant="outline-secondary"
-                >
-                  {({ closeDropdown }) => (
-                    <>
-                      <Dropdown.Item
-                        onClick={() => {
-                          setRevisionFormat("major-only");
-                          closeDropdown();
-                        }}
-                        active={revisionFormat === "major-only"}
-                      >
-                        {useNumberRevisions 
-                          ? (revisionStartAtOne ? "Major Only (1, 2, 3...)" : "Major Only (0, 1, 2...)")
-                          : "Major Only (A, B, C...)"}
-                      </Dropdown.Item>
-                      <Dropdown.Item
-                        onClick={() => {
-                          setRevisionFormat("major-minor");
-                          closeDropdown();
-                        }}
-                        active={revisionFormat === "major-minor"}
-                      >
-                        {useNumberRevisions 
-                          ? (revisionStartAtOne ? "Major-Minor (1-0, 1-1, 2-0...)" : "Major-Minor (0-0, 0-1, 1-0...)")
-                          : "Major-Minor (A-A, A-B, B-A...)"}
-                      </Dropdown.Item>
-                    </>
-                  )}
-                </DokulyDropdown>
-                <Form.Text className="text-muted">
-                  Choose the format for {useNumberRevisions ? "number" : "letter"}-based revisions. Major-minor format allows for more granular versioning with sub-revisions. 
-                  {useNumberRevisions && `For number-based revisions, the starting value shown above depends on the "Start major revisions at 1" setting.`}
-                </Form.Text>
-              </Form.Group>
-            </Col>
-          </Row>
-
-          <Row>
-            <Col md={12}>
-              <Form.Group className="mb-3">
-                <Form.Label>
-                  Part Number Template 
-                  <QuestionToolTip
-                    placement="right"
-                    optionalHelpText={
-                      "Configure how full part numbers are formatted. Available variables:\n" +
-                      "• <prefix> - Part type (PRT, ASM, PCBA, DOC)\n" +
-                      "• <part_number> - Numeric part number\n" +
-                      "• <major_revision> - Major revision (A, B, C or 0, 1, 2)\n" +
-                      "• <minor_revision> - Minor revision (A, B, C or 0, 1, 2)\n" +
-                      "• <revision> - Complete revision string (includes separator)\n" +
-                      "• <project_number> - Project number from associated project\n" +
-                      "• <day> - Day from creation date (01-31)\n" +
-                      "• <month> - Month from creation date (01-12)\n" +
-                      "• <year> - Year from creation date (e.g., 2025)\n\n" +
-                      "Example: '<prefix><part_number>-<revision>' → 'PRT10001-A-0'"
-                    }
-                  />
-                </Form.Label>
-                <Form.Control
-                  type="text"
-                  value={fullPartNumberTemplate}
-                  onChange={(e) => setFullPartNumberTemplate(e.target.value)}
-                  placeholder="<prefix><part_number><revision>"
-                  style={{ fontFamily: 'monospace' }}
                 />
+              </Form.Label>
+              <Form.Control
+                type="text"
+                value={fullPartNumberTemplate}
+                onChange={(e) => setFullPartNumberTemplate(e.target.value)}
+                placeholder="<prefix><part_number><revision>"
+                style={{ fontFamily: "monospace" }}
+              />
+              <Form.Text className="text-muted d-block mt-2">
+                Preview: {renderTemplateWithHighlights(fullPartNumberTemplate)}
+              </Form.Text>
+              {isLoadingPreview ? (
                 <Form.Text className="text-muted d-block mt-2">
-                  Preview: {renderTemplateWithHighlights(fullPartNumberTemplate)}
+                  Loading examples...
                 </Form.Text>
-                {isLoadingPreview ? (
-                  <Form.Text className="text-muted d-block mt-2">
-                    Loading examples...
+              ) : previewExamples.length > 0 ? (
+                <div className="mt-2">
+                  <Form.Text className="text-muted d-block">
+                    <strong>Examples:</strong>
                   </Form.Text>
-                ) : previewExamples.length > 0 ? (
-                  <div className="mt-2">
-                    <Form.Text className="text-muted d-block">
-                      <strong>Examples:</strong>
+                  {previewExamples.map((example, index) => (
+                    <Form.Text
+                      key={index}
+                      className="text-muted d-block"
+                      style={{ marginLeft: "1rem" }}
+                    >
+                      • {example.description}:{" "}
+                      <strong style={{ fontFamily: "monospace" }}>
+                        {example.formatted}
+                      </strong>
                     </Form.Text>
-                    {previewExamples.map((example, index) => (
-                      <Form.Text key={index} className="text-muted d-block" style={{ marginLeft: '1rem' }}>
-                        • {example.description}: <strong style={{ fontFamily: 'monospace' }}>{example.formatted}</strong>
-                      </Form.Text>
-                    ))}
-                  </div>
-                ) : null}
-              </Form.Group>
-            </Col>
-          </Row>
+                  ))}
+                </div>
+              ) : null}
+            </Form.Group>
+          </Col>
+        </Row>
 
-          <Row>
-            <Col md={12}>
-              <Form.Group className="mb-3">
-                <Form.Label>
-                  Standalone Revision Template 
-                  <QuestionToolTip
-                    placement="right"
-                    optionalHelpText={
-                      "Configure how standalone revisions are displayed (separate from full part numbers). Available variables:\n" +
-                      "• <major_revision> - Major revision (A, B, C or 0, 1, 2)\n" +
-                      "• <minor_revision> - Minor revision (A, B, C or 0, 1, 2)\n\n" +
-                      "Common examples:\n" +
-                      "• '<major_revision>' → 'A' or '0'\n" +
-                      "• '<major_revision>-<minor_revision>' → 'A-0' or '0-1'\n" +
-                      "• 'Rev <major_revision>' → 'Rev A' or 'Rev 0'\n" +
-                      "• 'v<major_revision>.<minor_revision>' → 'vA.0' or 'v0.1'"
-                    }
-                  />
-                </Form.Label>
-                <Form.Control
-                  type="text"
-                  value={formattedRevisionTemplate}
-                  onChange={(e) => setFormattedRevisionTemplate(e.target.value)}
-                  placeholder="<major_revision>"
-                  style={{ fontFamily: 'monospace' }}
+        <Row>
+          <Col md={12}>
+            <Form.Group className="mb-3">
+              <Form.Label>
+                Standalone Revision Template
+                <QuestionToolTip
+                  placement="right"
+                  optionalHelpText={
+                    "Configure how standalone revisions are displayed (separate from full part numbers). Available variables:\n" +
+                    "• <major_revision> - Major revision (A, B, C or 0, 1, 2)\n" +
+                    "• <minor_revision> - Minor revision (A, B, C or 0, 1, 2)\n\n" +
+                    "Common examples:\n" +
+                    "• '<major_revision>' → 'A' or '0'\n" +
+                    "• '<major_revision>-<minor_revision>' → 'A-0' or '0-1'\n" +
+                    "• 'Rev <major_revision>' → 'Rev A' or 'Rev 0'\n" +
+                    "• 'v<major_revision>.<minor_revision>' → 'vA.0' or 'v0.1'"
+                  }
                 />
+              </Form.Label>
+              <Form.Control
+                type="text"
+                value={formattedRevisionTemplate}
+                onChange={(e) => setFormattedRevisionTemplate(e.target.value)}
+                placeholder="<major_revision>"
+                style={{ fontFamily: "monospace" }}
+              />
+              <Form.Text className="text-muted d-block mt-2">
+                This controls how revisions are displayed in standalone contexts
+                (e.g., revision columns in tables).
+              </Form.Text>
+              <Form.Text className="text-muted d-block mt-2">
+                Preview:{" "}
+                {renderTemplateWithHighlights(formattedRevisionTemplate)}
+              </Form.Text>
+              {isLoadingRevisionPreview ? (
                 <Form.Text className="text-muted d-block mt-2">
-                  This controls how revisions are displayed in standalone contexts (e.g., revision columns in tables).
+                  Loading examples...
                 </Form.Text>
-                <Form.Text className="text-muted d-block mt-2">
-                  Preview: {renderTemplateWithHighlights(formattedRevisionTemplate)}
-                </Form.Text>
-                {isLoadingRevisionPreview ? (
-                  <Form.Text className="text-muted d-block mt-2">
-                    Loading examples...
+              ) : revisionPreviewExamples.length > 0 ? (
+                <div className="mt-2">
+                  <Form.Text className="text-muted d-block">
+                    <strong>Examples:</strong>
                   </Form.Text>
-                ) : revisionPreviewExamples.length > 0 ? (
-                  <div className="mt-2">
-                    <Form.Text className="text-muted d-block">
-                      <strong>Examples:</strong>
+                  {revisionPreviewExamples.map((example, index) => (
+                    <Form.Text
+                      key={index}
+                      className="text-muted d-block"
+                      style={{ marginLeft: "1rem" }}
+                    >
+                      • {example.description}:{" "}
+                      <strong style={{ fontFamily: "monospace" }}>
+                        {example.formatted}
+                      </strong>
                     </Form.Text>
-                    {revisionPreviewExamples.map((example, index) => (
-                      <Form.Text key={index} className="text-muted d-block" style={{ marginLeft: '1rem' }}>
-                        • {example.description}: <strong style={{ fontFamily: 'monospace' }}>{example.formatted}</strong>
-                      </Form.Text>
-                    ))}
-                  </div>
-                ) : null}
-              </Form.Group>
-            </Col>
-          </Row>
+                  ))}
+                </div>
+              ) : null}
+            </Form.Group>
+          </Col>
+        </Row>
 
-          {/* Available Keywords Reference - applies to both templates above */}
-          <Row>
-            <Col md={12}>
-              <div className="mt-3 mb-4">
-                <details>
-                  <summary style={{ cursor: 'pointer', color: 'black', fontWeight: 'bold' }}>
-                    Available Template Keywords
-                  </summary>
-                  <div className="mt-2 p-2" style={{ backgroundColor: '#f8f9fa', borderRadius: '4px' }}>
-                    {availableKeywords.map((kw, index) => (
-                      <div key={index} className="mb-2">
-                        <code style={{ 
-                          backgroundColor: '#155216', 
-                          color: 'white', 
-                          padding: '2px 6px', 
-                          borderRadius: '4px',
-                          fontFamily: 'monospace'
-                        }}>
-                          {kw.keyword}
-                        </code>
-                        <span className="ms-2 text-muted">{kw.description}</span>
-                      </div>
-                    ))}
-                  </div>
-                </details>
-              </div>
-            </Col>
-          </Row>
-
-          <Row>
-            <Col md={12}>
-              <div className="alert alert-info">
-                <strong>Current Configuration:</strong>
-                <ul className="mb-0 mt-2">
-                  <li>
-                    <strong>Revision Type:</strong> {useNumberRevisions ? "Number-based" : "Letter-based"}
-                  </li>
-                  <li>
-                    <strong>Format:</strong> {revisionFormat === "major-only" ? "Major only" : "Major-minor"}
-                  </li>
-                  {useNumberRevisions && (
-                    <li>
-                      <strong>Major revision starts at:</strong> {revisionStartAtOne ? "1" : "0"}
-                    </li>
-                  )}
-                  <li>
-                    <strong>Part Number Template:</strong> {renderTemplateWithHighlights(fullPartNumberTemplate)}
-                  </li>
-                  <li>
-                    <strong>Standalone Revision Template:</strong> {renderTemplateWithHighlights(formattedRevisionTemplate)}
-                  </li>
-                </ul>
-              </div>
-            </Col>
-          </Row>
-
-          <Row>
-            <Col md={12}>
-              <div className="mb-3">
-                <SubmitButton
-                  onClick={handleSave}
-                  disabled={!hasChanges || isUpdating}
-                  disabledTooltip={!hasChanges ? "No changes to save" : "Saving settings..."}
+        {/* Available Keywords Reference - applies to both templates above */}
+        <Row>
+          <Col md={12}>
+            <div className="mt-3 mb-4">
+              <details>
+                <summary
+                  style={{
+                    cursor: "pointer",
+                    color: "black",
+                    fontWeight: "bold",
+                  }}
                 >
-                  {isUpdating ? "Saving..." : "Save Settings"}
-                </SubmitButton>
-              </div>
-            </Col>
-          </Row>
-        </Form>
+                  Available Template Keywords
+                </summary>
+                <div
+                  className="mt-2 p-2"
+                  style={{ backgroundColor: "#f8f9fa", borderRadius: "4px" }}
+                >
+                  {availableKeywords.map((kw, index) => (
+                    <div key={index} className="mb-2">
+                      <code
+                        style={{
+                          backgroundColor: "#155216",
+                          color: "white",
+                          padding: "2px 6px",
+                          borderRadius: "4px",
+                          fontFamily: "monospace",
+                        }}
+                      >
+                        {kw.keyword}
+                      </code>
+                      <span className="ms-2 text-muted">{kw.description}</span>
+                    </div>
+                  ))}
+                </div>
+              </details>
+            </div>
+          </Col>
+        </Row>
+
+        <Row>
+          <Col md={12}>
+            <div className="alert alert-info">
+              <strong>Current Configuration:</strong>
+              <ul className="mb-0 mt-2">
+                <li>
+                  <strong>Revision Type:</strong>{" "}
+                  {useNumberRevisions ? "Number-based" : "Letter-based"}
+                </li>
+                <li>
+                  <strong>Format:</strong>{" "}
+                  {revisionFormat === "major-only"
+                    ? "Major only"
+                    : "Major-minor"}
+                </li>
+                {useNumberRevisions && (
+                  <li>
+                    <strong>Major revision starts at:</strong>{" "}
+                    {revisionStartAtOne ? "1" : "0"}
+                  </li>
+                )}
+                <li>
+                  <strong>Part Number Template:</strong>{" "}
+                  {renderTemplateWithHighlights(fullPartNumberTemplate)}
+                </li>
+                <li>
+                  <strong>Standalone Revision Template:</strong>{" "}
+                  {renderTemplateWithHighlights(formattedRevisionTemplate)}
+                </li>
+              </ul>
+            </div>
+          </Col>
+        </Row>
+
+        <Row>
+          <Col md={12}>
+            <div className="mb-3">
+              <SubmitButton
+                onClick={handleSave}
+                disabled={!hasChanges || isUpdating}
+                disabledTooltip={
+                  !hasChanges ? "No changes to save" : "Saving settings..."
+                }
+              >
+                {isUpdating ? "Saving..." : "Save Settings"}
+              </SubmitButton>
+            </div>
+          </Col>
+        </Row>
+      </Form>
     </div>
   );
 };

--- a/dokuly/organizations/revision_utils.py
+++ b/dokuly/organizations/revision_utils.py
@@ -130,11 +130,13 @@ def build_full_part_number(
         template = org.full_part_number_template
         use_number_revisions = org.use_number_revisions
         start_at_one = org.start_major_revision_at_one
+        revision_format = org.revision_format
     except Organization.DoesNotExist:
         # Fallback to defaults
         template = "<prefix><part_number><major_revision>"
         use_number_revisions = False
         start_at_one = False
+        revision_format = "major-only"
     
     return build_full_part_number_from_template(
         template=template,
@@ -146,6 +148,7 @@ def build_full_part_number(
         start_at_one=start_at_one,
         project_number=project_number,
         created_at=created_at,
+        revision_format=revision_format,
     )
 
 
@@ -157,6 +160,7 @@ def build_formatted_revision(
     revision_count_minor: int,
     project_number: Optional[str] = None,
     created_at: Optional[object] = None,
+    revision_format: Optional[str] = None,
 ) -> str:
     """
     Build a full part number using organization settings and template.
@@ -192,11 +196,14 @@ def build_formatted_revision(
         template = org.formatted_revision_template
         use_number_revisions = org.use_number_revisions
         start_at_one = org.start_major_revision_at_one
+        # Caller may override revision_format (e.g. documents pass document_revision_format)
+        effective_revision_format = revision_format if revision_format is not None else org.revision_format
     except Organization.DoesNotExist:
         # Fallback to defaults
         template = "<major_revision>"
         use_number_revisions = False
         start_at_one = False
+        effective_revision_format = revision_format if revision_format is not None else "major-only"
     
     return build_full_part_number_from_template(
         template=template,
@@ -208,6 +215,7 @@ def build_formatted_revision(
         start_at_one=start_at_one,
         project_number=project_number,
         created_at=created_at,
+        revision_format=effective_revision_format,
     )
 
 
@@ -221,6 +229,7 @@ def build_full_part_number_from_template(
     start_at_one: bool = False,
     project_number: Optional[str] = None,
     created_at: Optional[object] = None,
+    revision_format: str = "major-only",
 ) -> str:
     """
     Build a full part number from a template and revision counts.
@@ -275,11 +284,17 @@ def build_full_part_number_from_template(
             # If created_at is not a datetime object or is invalid, use empty strings
             pass
     
+    # Build the combined <revision> value based on revision_format
+    if revision_format == "major-minor":
+        revision_combined = f"{major_formatted}-{minor_formatted}"
+    else:
+        revision_combined = major_formatted
+
     # Replace template variables
     result = template
     result = result.replace("<prefix>", prefix_str)
     result = result.replace("<part_number>", part_number_str)
-    result = result.replace("<revision>", major_formatted)
+    result = result.replace("<revision>", revision_combined)
     result = result.replace("<major_revision>", major_formatted)
     result = result.replace("<minor_revision>", minor_formatted)
     result = result.replace("<project_number>", project_number_str)
@@ -660,11 +675,13 @@ def build_full_document_number(
         # Use document-specific revision settings
         use_number_revisions = org.document_use_number_revisions
         start_at_one = org.document_start_major_revision_at_one
+        revision_format = org.document_revision_format
     except Organization.DoesNotExist:
         # Fallback to defaults
         template = "<prefix><project_number>-<document_number><revision>"
         use_number_revisions = False
         start_at_one = False
+        revision_format = "major-only"
     
     return build_full_document_number_from_template(
         template=template,
@@ -677,6 +694,7 @@ def build_full_document_number(
         project_number=project_number,
         part_number=part_number,
         created_at=created_at,
+        revision_format=revision_format,
     )
 
 
@@ -691,6 +709,7 @@ def build_full_document_number_from_template(
     project_number: Optional[str] = None,
     part_number: Optional[str] = None,
     created_at: Optional[object] = None,
+    revision_format: str = "major-only",
 ) -> str:
     """
     Build a full document number from a template and revision counts.
@@ -748,13 +767,19 @@ def build_full_document_number_from_template(
             # If created_at is not a datetime object or is invalid, use empty strings
             pass
     
+    # Build the combined <revision> value based on revision_format
+    if revision_format == "major-minor":
+        revision_combined = f"{major_formatted}-{minor_formatted}"
+    else:
+        revision_combined = major_formatted
+
     # Replace template variables
     result = template
     result = result.replace("<prefix>", prefix_str)
     result = result.replace("<document_number>", document_number_str)
     result = result.replace("<project_number>", project_number_str)
     result = result.replace("<part_number>", part_number_str)
-    result = result.replace("<revision>", major_formatted)
+    result = result.replace("<revision>", revision_combined)
     result = result.replace("<major_revision>", major_formatted)
     result = result.replace("<minor_revision>", minor_formatted)
     result = result.replace("<day>", day_str)

--- a/dokuly/organizations/views.py
+++ b/dokuly/organizations/views.py
@@ -601,6 +601,7 @@ def preview_part_number_template(request):
         template = request.data.get('template', '<prefix><part_number><revision>')
         use_number_revisions = request.data.get('use_number_revisions', False)
         start_at_one = request.data.get('start_major_revision_at_one', False)
+        revision_format = request.data.get('revision_format', 'major-only')
         
         # Create sample datetime for date-based variables
         sample_date = datetime(2025, 1, 15, 10, 30, 0)  # Jan 15, 2025
@@ -621,6 +622,7 @@ def preview_part_number_template(request):
                 start_at_one=start_at_one,
                 project_number='PRJ001',
                 created_at=sample_date,
+                revision_format=revision_format,
             )
         })
         
@@ -637,6 +639,7 @@ def preview_part_number_template(request):
                 start_at_one=start_at_one,
                 project_number='PRJ042',
                 created_at=sample_date,
+                revision_format=revision_format,
             )
         })
         
@@ -653,6 +656,7 @@ def preview_part_number_template(request):
                 start_at_one=start_at_one,
                 project_number='PRJ100',
                 created_at=sample_date,
+                revision_format=revision_format,
             )
         })
         
@@ -708,6 +712,7 @@ def preview_formatted_revision_template(request):
                 revision_count_minor=0,
                 use_number_revisions=use_number_revisions,
                 start_at_one=start_at_one,
+                revision_format=revision_format,
             )
         })
         
@@ -723,6 +728,7 @@ def preview_formatted_revision_template(request):
                     revision_count_minor=1,
                     use_number_revisions=use_number_revisions,
                     start_at_one=start_at_one,
+                    revision_format=revision_format,
                 )
             })
         
@@ -737,6 +743,7 @@ def preview_formatted_revision_template(request):
                 revision_count_minor=0,
                 use_number_revisions=use_number_revisions,
                 start_at_one=start_at_one,
+                revision_format=revision_format,
             )
         })
         
@@ -777,6 +784,7 @@ def preview_document_number_template(request):
         template = request.data.get('template', '<prefix><project_number>-<document_number><revision>')
         use_number_revisions = request.data.get('use_number_revisions', False)
         start_at_one = request.data.get('start_major_revision_at_one', False)
+        revision_format = request.data.get('revision_format', 'major-only')
         
         # Create sample datetime for date-based variables
         sample_date = datetime(2025, 1, 15, 10, 30, 0)  # Jan 15, 2025
@@ -798,6 +806,7 @@ def preview_document_number_template(request):
                 project_number='1001',
                 part_number='10001',
                 created_at=sample_date,
+                revision_format=revision_format,
             )
         })
         
@@ -815,6 +824,7 @@ def preview_document_number_template(request):
                 project_number='2042',
                 part_number='20045',
                 created_at=sample_date,
+                revision_format=revision_format,
             )
         })
         
@@ -832,6 +842,7 @@ def preview_document_number_template(request):
                 project_number='3100',
                 part_number='30012',
                 created_at=sample_date,
+                revision_format=revision_format,
             )
         })
         


### PR DESCRIPTION
- fix document number template preview for major-minor format
- fix the same logic for part number in the organization revision utils helpers