### PR TITLE
Ensure full display name is shown

### DIFF
--- a/dokuly/frontend/src/components/App.css
+++ b/dokuly/frontend/src/components/App.css
@@ -1024,15 +1024,11 @@ input[type=number] {
 }
 
 .title-container {
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: break-word;
+  word-break: break-word;
   line-height: 1.3;
   height: auto;
-  max-height: 3.9em;
-  white-space: normal;
   padding-right: 50px;
   width: 100%;
   text-align: left;

--- a/dokuly/frontend/src/components/assemblies/forms/asmEditForm.js
+++ b/dokuly/frontend/src/components/assemblies/forms/asmEditForm.js
@@ -146,7 +146,7 @@ const AsmEditForm = (props) => {
         <div className="d-flex" style={{ gap: "24px" }}>
           {/* Left column: fields */}
           <div style={{ flex: 1, minWidth: 0 }}>
-            <FormField label="Display name" required>
+            <FormField label="Display name" required hint={`${(display_name || "").length}/150`}>
               <input
                 className="form-control"
                 type="text"

--- a/dokuly/frontend/src/components/assemblies/forms/assemblyNewForm.js
+++ b/dokuly/frontend/src/components/assemblies/forms/assemblyNewForm.js
@@ -104,14 +104,14 @@ const NewAssemblyForm = (props) => {
         onHide={() => setShowModal(false)}
         title="Create new assembly"
       >
-        <FormField label="Display name" required>
+        <FormField label="Display name" required hint={`${(display_name || "").length}/150`}>
           <input
             className="form-control"
             type="text"
             name="display_name"
             onChange={(e) => {
-              if (e.target.value.length > 100) {
-                alert("Max length 50");
+              if (e.target.value.length > 150) {
+                toast.info("Max length 150");
                 return;
               }
               setDisplayName(e.target.value);

--- a/dokuly/frontend/src/components/documents/documentNewForm2.js
+++ b/dokuly/frontend/src/components/documents/documentNewForm2.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { toast } from "react-toastify";
 
 import { get_active_customers } from "../customers/funcitons/queries";
 import { getActiveProjectByCustomer, fetchProjects } from "../projects/functions/queries";
@@ -139,14 +140,14 @@ const NewDocumentForm = (props) => {
         onHide={() => setShowModal(false)}
         title="Create new document"
       >
-        <FormField label="Title" required>
+        <FormField label="Title" required hint={`${(title || "").length}/1000`}>
           <input
             className="form-control"
             type="text"
             name="title"
             onChange={(e) => {
               if (e.target.value.length > 1000) {
-                alert("Max length 1000");
+                toast.info("Max length 1000");
                 return;
               }
               setTitle(e.target.value);

--- a/dokuly/frontend/src/components/documents/forms/documentsEditForm.js
+++ b/dokuly/frontend/src/components/documents/forms/documentsEditForm.js
@@ -125,14 +125,14 @@ const DocumentEditForm = (props) => {
           <div className="d-flex" style={{ gap: "24px" }}>
             {/* -- Left column: fields -- */}
             <div style={{ flex: 1, minWidth: 0 }}>
-              <FormField label="Title" required>
+              <FormField label="Title" required hint={`${(title || "").length}/1000`}>
                 <input
                   className="form-control"
                   type="text"
                   name="title"
                   onChange={(e) => {
                     if (e.target.value.length > 1000) {
-                      alert("Max length 1000");
+                      toast.info("Max length 1000");
                       return;
                     }
                     setTitle(e.target.value);

--- a/dokuly/frontend/src/components/dokuly_components/Heading.js
+++ b/dokuly/frontend/src/components/dokuly_components/Heading.js
@@ -23,27 +23,16 @@ const Heading = ({
     const titleElement = titleRef.current;
     if (!titleElement) return;
 
+    // Scale font size down slightly for very long names, but always allow full wrapping
     const maxFontSize = 32;
-    let fontSize = maxFontSize; // Start with maxFontSize
-    titleElement.style.fontSize = `${fontSize}px`;
-
-    // Adapt font size and div size based on the length of the content and viewport width
-    if (window.innerWidth > 768 && display_name.length <= 60) {
-      // When the screen is large and content is short, allow up to 2 lines
-      titleElement.style["-webkit-line-clamp"] = "2";
-      titleElement.style.height = "auto";
-      titleElement.style.maxHeight = "2.6em";
-    } else {
-      // Adjust for other conditions more dynamically
-      titleElement.style.whiteSpace = "normal";
-      while (
-        titleElement.scrollHeight > titleElement.clientHeight &&
-        fontSize > 12
-      ) {
-        fontSize--;
-        titleElement.style.fontSize = `${fontSize}px`;
-      }
+    const minFontSize = 14;
+    let fontSize = maxFontSize;
+    if (display_name.length > 100) {
+      fontSize = minFontSize + 4;
+    } else if (display_name.length > 60) {
+      fontSize = 20;
     }
+    titleElement.style.fontSize = `${fontSize}px`;
   };
 
   useEffect(() => {

--- a/dokuly/frontend/src/components/parts/forms/editPartForm.js
+++ b/dokuly/frontend/src/components/parts/forms/editPartForm.js
@@ -269,12 +269,18 @@ const EditPartForm = (props) => {
         <div className="d-flex" style={{ gap: "24px" }}>
           {/* ── Left column: fields ── */}
           <div style={{ flex: 1, minWidth: 0 }}>
-            <FormField label="Display name" required>
+            <FormField label="Display name" required hint={`${(display_name || "").length}/150`}>
               <input
                 className="form-control"
                 type="text"
                 value={display_name}
-                onChange={(e) => setDisplayName(e.target.value)}
+                onChange={(e) => {
+                  if (e.target.value.length > 150) {
+                    toast.info("Max length 150");
+                    return;
+                  }
+                  setDisplayName(e.target.value);
+                }}
               />
               <NameSuggestion
                 draftName={display_name}

--- a/dokuly/frontend/src/components/parts/forms/newPartForm2.js
+++ b/dokuly/frontend/src/components/parts/forms/newPartForm2.js
@@ -1176,12 +1176,16 @@ const PartNewForm = (props) => {
         onHide={() => setShowModal(false)}
         title="Create new part"
       >
-        <FormField label="Display name" required>
+        <FormField label="Display name" required hint={`${(display_name || "").length}/150`}>
           <input
             className="form-control"
             type="text"
             name="display_name"
             onChange={(e) => {
+              if (e.target.value.length > 150) {
+                toast.info("Max length 150");
+                return;
+              }
               setDisplayName(e.target.value);
             }}
             value={display_name || ""}

--- a/dokuly/frontend/src/components/pcbas/forms/pcbaEditForm2.js
+++ b/dokuly/frontend/src/components/pcbas/forms/pcbaEditForm2.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router";
+import { toast } from "react-toastify";
 import { editPcba, archivePcba } from "../functions/queries";
 import DokulyModal from "../../dokuly_components/dokulyModal";
 import ExternalPartNumberFormGroup from "../../common/forms/externalPartNumberFormGroup";
@@ -154,14 +155,14 @@ const PcbaForm = (props) => {
         >
           <div className="d-flex" style={{ gap: "24px" }}>
             <div style={{ flex: 1, minWidth: 0 }}>
-              <FormField label="Display Name" required>
+              <FormField label="Display Name" required hint={`${(display_name || "").length}/150`}>
                 <input
                   className="form-control"
                   type="text"
                   name="display_name"
                   onChange={(e) => {
-                    if (e.target.value.length > 100) {
-                      alert("Max length 50");
+                    if (e.target.value.length > 150) {
+                      toast.info("Max length 150");
                       return;
                     }
                     setDisplayName(e.target.value);

--- a/dokuly/frontend/src/components/pcbas/forms/pcbaNewForm.js
+++ b/dokuly/frontend/src/components/pcbas/forms/pcbaNewForm.js
@@ -95,14 +95,14 @@ const NewPcbaForm = (props) => {
         onHide={() => setShowModal(false)}
         title="Create new PCBA"
       >
-        <FormField label="Display name" required>
+        <FormField label="Display name" required hint={`${(display_name || "").length}/150`}>
           <input
             className="form-control"
             type="text"
             name="display_name"
             onChange={(e) => {
-              if (e.target.value.length > 100) {
-                alert("Max length 50");
+              if (e.target.value.length > 150) {
+                toast.info("Max length 150");
                 return;
               }
               setDisplayName(e.target.value);


### PR DESCRIPTION
Now shows entire name:
<img width="1366" height="462" alt="image" src="https://github.com/user-attachments/assets/e6861fef-0ee7-4c9b-a4ad-e8ce7d12449f" />

Closes #462

And add letter count to display name modal fields.
<img width="586" height="182" alt="image" src="https://github.com/user-attachments/assets/4423a75c-a1e6-44c3-91d7-e80c425b0e6c" />

